### PR TITLE
fix compile error with VC 2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 bin/
 build/
 *.vs/
+*.VC.db
+*.VC.opendb

--- a/src/dbg_breakpoint.cpp
+++ b/src/dbg_breakpoint.cpp
@@ -119,7 +119,7 @@ namespace vscode
 		}
 
 		fs::path* cliptr = 0;
-		if (pathconvert.fget(server_path, cliptr))
+		if (pathconvert.fget(path_to_string(server_path), cliptr))
 		{
 			auto it = client_map_.find(*cliptr);
 			if (it == client_map_.end())
@@ -128,7 +128,7 @@ namespace vscode
 		}
 
 		fs::path client_path;
-		custom::result r = pathconvert.eval(server_path, client_path);
+		custom::result r = pathconvert.eval(path_to_string(server_path), client_path);
 		switch (r)
 		{
 		case custom::result::failed:

--- a/src/dbg_delayload.cpp
+++ b/src/dbg_delayload.cpp
@@ -38,7 +38,9 @@ namespace delayload
 	}
 }
 
-
+#ifndef DELAYIMP_INSECURE_WRITABLE_HOOKS
+const
+#endif
 PfnDliHook __pfnDliNotifyHook2 = delayload::hook;
 
 #endif

--- a/src/dbg_path.h
+++ b/src/dbg_path.h
@@ -4,6 +4,7 @@
 
 #if _MSC_VER >= 1900
 namespace fs = std::experimental::filesystem::v1;
+#define path_to_string(x) (x).string()
 #else
 namespace fs_ = std::tr2::sys;
 
@@ -65,6 +66,7 @@ namespace fs {
 		fs_::current_path(p);
 	}
 }
+#define path_to_string(x) (x)
 #endif
 
 namespace vscode


### PR DESCRIPTION
std::experimental::filesystem::v1::path use explict .tostring() method for converting to std::string(). And delay hook has different declare if not defined DELAYIMP_INSECURE_WRITABLE_HOOKS.