### PR TITLE
取消attach时断点信息未清理干净

### DIFF
--- a/include/debugger/hashmap.h
+++ b/include/debugger/hashmap.h
@@ -76,6 +76,7 @@ namespace vscode {
                 front_chunk->next = t->next;
                 delete t;
             }
+	    back_chunk = front_chunk;
             pos = 0;
         }
 

--- a/include/debugger/hashmap.h
+++ b/include/debugger/hashmap.h
@@ -70,6 +70,15 @@ namespace vscode {
 			del_back();
 		}
 
+        void clear() {
+            while (front_chunk->next) {
+                chunk_type* t = front_chunk->next;
+                front_chunk->next = t->next;
+                delete t;
+            }
+            pos = 0;
+        }
+
 	private:
 		hashnode<T>* get_node(uintptr_t key) {
 			for (chunk_type* c = front_chunk; c != back_chunk; c = c->next) {
@@ -126,6 +135,10 @@ namespace vscode {
 		void del(uintptr_t key) {
 			return buckets[key % BucketSize].del(key);
 		}
+        void clear() {
+            for (size_t i = 0; i < BucketSize; ++i)
+                buckets[i].clear();
+        }
 	private:
 		hashbucket<T, ChunkSize> buckets[BucketSize];
 	};

--- a/src/debugger/breakpoint.cpp
+++ b/src/debugger/breakpoint.cpp
@@ -279,6 +279,7 @@ namespace vscode
 	{
 		files_.clear();
 		memorys_.clear();
+        functions_.clear();
 	}
 
 	bool breakpointMgr::has(bp_source* src, size_t line, debug& debug) const


### PR DESCRIPTION
取消attach时functions_  里面用到的指针对应的数据被销毁，但是没有清理functions_，再次attach时会拿到functions_里已经失效的指针